### PR TITLE
feat(android): update android sdk version for notification-hubs-android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     implementation platform('com.google.firebase:firebase-bom:30.5.0')
     implementation 'com.google.firebase:firebase-messaging'
     implementation "com.google.firebase:firebase-iid"
-    implementation 'com.microsoft.azure:notification-hubs-android-sdk:0.6'
+    implementation 'com.microsoft.azure:notification-hubs-android-sdk:2.0.0'
 }
 
 repositories {


### PR DESCRIPTION
Google is going to stop supporting the legacy FCM API by the 20th of June 2024. To ensure customers continue receiving push notifications, both the backend and frontend need to be updated to implement the new API as soon as possible.
So we have to adjust the internal android sdk version used in the package and patch it to migrate to the new FCM V1 instead of the legacy one that will be deprecated soon.